### PR TITLE
Renamed EventRef Definition

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3938,7 +3938,7 @@ Allows defining invocation of a function via event.
 | --- | --- | --- | --- |
 | [produceEventRef](#Event-Definition) | Reference to the unique name of a `produced` event definition | string | yes |
 | [consumeEventRef](#Event-Definition) | Reference to the unique name of a `consumed` event definition | string | no |
-| resultEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the result event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
+| consumeEventTimeout | Maximum amount of time (ISO 8601 format) to wait for the consume event. If not defined it be set to the [actionExecutionTimeout](#Workflow-Timeout-Definition) | string | no |
 | data | If string type, an expression which selects parts of the states data output to become the data (payload) of the event referenced by `produceEventRef`. If object type, a custom object to become the data (payload) of the event referenced by `produceEventRef`. | string or object | no |
 | contextAttributes | Add additional event extension context attributes to the trigger/produced event | object | no |
 | invoke | Specifies if the function should be invoked sync or async. Default is sync | string | no |


### PR DESCRIPTION
Renamed EventRef Definition's `resultEventTimeout` to `consumeEventTimeout`

**Many thanks for submitting your Pull Request :heart:!**

**Please specify parts this PR updates:**

- [x ] Specification
- [ ] Schema
- [ ] Examples
- [ ] Extensions
- [ ] Roadmap
- [ ] Use Cases
- [ ] Community
- [ ] TCK
- [ ] Other

**What this PR does / why we need it**:

The `resultEventTimeout ` is an artifact from the time `consumeEventRef` was named `resultEventRef`, and needs to pe properly renamed.